### PR TITLE
Address OnItemSelectedListener firing unnecessarily; refactoring for flexibility to move forward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /.idea/assetWizardSettings.xml
 /.idea/modules.xml
 /.idea/navEditor.xml
-/.idea/uiDesigner.xml
+# /.idea/uiDesigner.xml
 /.idea/workspace.xml
 /.idea/vcs.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,13 @@
 /.idea/caches
 /.idea/codeStyles
 /.idea/libraries
+
+/.idea/$CACHE_FILE$
 /.idea/assetWizardSettings.xml
 /.idea/modules.xml
-/.idea/workspace.xml
 /.idea/navEditor.xml
+/.idea/uiDesigner.xml
+/.idea/workspace.xml
 /.idea/vcs.xml
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /.idea/assetWizardSettings.xml
 /.idea/modules.xml
 /.idea/navEditor.xml
-# /.idea/uiDesigner.xml
+/.idea/uiDesigner.xml
 /.idea/workspace.xml
 /.idea/vcs.xml
 

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Imgur Browser

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+          </set>
+        </option>
+        <option name="useQualifiedModuleNames" value="true" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/controller/GallerySearchFragment.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/controller/GallerySearchFragment.java
@@ -12,7 +12,8 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.RecyclerView;
 import edu.cnm.deepdive.browseimgur.R;
-import edu.cnm.deepdive.browseimgur.model.entity.Gallery;
+import edu.cnm.deepdive.browseimgur.model.Gallery;
+import edu.cnm.deepdive.browseimgur.model.Image;
 import edu.cnm.deepdive.browseimgur.view.GalleryListAdapter;
 import edu.cnm.deepdive.browseimgur.viewmodel.ListViewModel;
 
@@ -40,12 +41,10 @@ public class GallerySearchFragment extends Fragment implements
     super.onViewCreated(view, savedInstanceState);
     viewModel = new ViewModelProvider(getActivity())
         .get(ListViewModel.class);
-    viewModel.getSearchResult().observe(getViewLifecycleOwner(), searchResult -> {
-      if (searchResult != null) {
+    viewModel.getGalleries().observe(getViewLifecycleOwner(), (galleries) -> {
+      if (galleries != null) {
         galleryArray.setVisibility(View.VISIBLE);
-        galleryArray.setAdapter(new GalleryListAdapter(getContext(), searchResult.getData(),
-            this::onSelected));
-
+        galleryArray.setAdapter(new GalleryListAdapter(getContext(), galleries, this));
       }
     });
     viewModel.getLoading().observe(getViewLifecycleOwner(), loading -> {
@@ -64,12 +63,9 @@ public class GallerySearchFragment extends Fragment implements
   }
 
   @Override
-  public void onSelected(int index, Gallery gallery) {
-    imageDialogDetail(gallery);
-  }
-
-  private void imageDialogDetail(Gallery gallery) {
+  public void onSelected(Gallery gallery, Image image) {
     ImageDetailDialogFragment fragment = ImageDetailDialogFragment.newInstance();
     fragment.show(getChildFragmentManager(), fragment.getClass().getName());
   }
+
 }

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/model/Album.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/model/Album.java
@@ -1,6 +1,8 @@
-package edu.cnm.deepdive.browseimgur.model.entity;
+package edu.cnm.deepdive.browseimgur.model;
 
 import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
 
 public class Album {
 
@@ -17,7 +19,8 @@ public class Album {
   private int datetime;
 
   @Expose
-  private String account_url; // nullable
+  @SerializedName("account_url")
+  private String accountUrl; // nullable
 
   @Expose
   private int views;
@@ -32,10 +35,11 @@ public class Album {
   private int images_count;
 
   @Expose
-  private Image[] images;
+  private List<Image> images;
 
   @Expose
-  private boolean in_gallery;
+  @SerializedName("in_gallery")
+  private boolean inGallery;
 
   public String getId() {
     return id;
@@ -69,12 +73,12 @@ public class Album {
     this.datetime = datetime;
   }
 
-  public String getAccount_url() {
-    return account_url;
+  public String getAccountUrl() {
+    return accountUrl;
   }
 
-  public void setAccount_url(String account_url) {
-    this.account_url = account_url;
+  public void setAccountUrl(String accountUrl) {
+    this.accountUrl = accountUrl;
   }
 
   public int getViews() {
@@ -109,19 +113,19 @@ public class Album {
     this.images_count = images_count;
   }
 
-  public Image[] getImages() {
+  public List<Image> getImages() {
     return images;
   }
 
-  public void setImages(Image[] images) {
+  public void setImages(List<Image> images) {
     this.images = images;
   }
 
-  public boolean isIn_gallery() {
-    return in_gallery;
+  public boolean isInGallery() {
+    return inGallery;
   }
 
-  public void setIn_gallery(boolean in_gallery) {
-    this.in_gallery = in_gallery;
+  public void setInGallery(boolean inGallery) {
+    this.inGallery = inGallery;
   }
 }

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/model/Gallery.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/model/Gallery.java
@@ -1,7 +1,7 @@
-package edu.cnm.deepdive.browseimgur.model.entity;
+package edu.cnm.deepdive.browseimgur.model;
 
 import com.google.gson.annotations.Expose;
-import java.util.Arrays;
+import java.util.List;
 
 public class Gallery {
 
@@ -17,10 +17,10 @@ public class Gallery {
 
   private String link;
 
-  private Tag[] tags;
+  private List<Tag> tags;
 
   @Expose
-  private Image[] images;
+  private List<Image> images;
 
   public String getId() {
     return id;
@@ -54,7 +54,7 @@ public class Gallery {
     this.datetime = datetime;
   }
 
-  public Tag[] getTags() {
+  public List<Tag> getTags() {
     return tags;
   }
 
@@ -66,40 +66,40 @@ public class Gallery {
     this.link = link;
   }
 
-  public void setTags(Tag[] tags) {
+  public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
-  public Image[] getImages() {
+  public List<Image> getImages() {
     return images;
   }
 
-  public void setImages(Image[] images) {
+  public void setImages(List<Image> images) {
     this.images = images;
   }
 
   @Override
   public String toString() {
-    return title + description + Arrays.toString(images);
+    return title + description + images.toString();
   }
 
   public static class SearchResult {
 
     @Expose
-    Gallery[] data;
+    private List<Gallery> data;
 
-    public Gallery[] getData() {
+    public List<Gallery> getData() {
       return data;
     }
 
-    public void setData(Gallery[] data) {
+    public void setData(List<Gallery> data) {
       this.data = data;
     }
 
     @Override
     public String toString() {
       return "SearchResult{" +
-          "data=" + Arrays.toString(getData());
+          "data=" + data.toString();
     }
   }
 

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/model/Image.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/model/Image.java
@@ -1,4 +1,4 @@
-package edu.cnm.deepdive.browseimgur.model.entity;
+package edu.cnm.deepdive.browseimgur.model;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/model/Tag.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/model/Tag.java
@@ -1,4 +1,4 @@
-package edu.cnm.deepdive.browseimgur.model.entity;
+package edu.cnm.deepdive.browseimgur.model;
 
 import com.google.gson.annotations.Expose;
 

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/service/ImgurService.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/service/ImgurService.java
@@ -3,7 +3,7 @@ package edu.cnm.deepdive.browseimgur.service;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import edu.cnm.deepdive.browseimgur.BuildConfig;
-import edu.cnm.deepdive.browseimgur.model.entity.Gallery;
+import edu.cnm.deepdive.browseimgur.model.Gallery;
 import io.reactivex.Single;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/view/GalleryImageAdapter.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/view/GalleryImageAdapter.java
@@ -11,13 +11,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.squareup.picasso.Picasso;
 import edu.cnm.deepdive.browseimgur.R;
-import edu.cnm.deepdive.browseimgur.model.entity.Image;
+import edu.cnm.deepdive.browseimgur.model.Image;
+import java.util.List;
 
 public class GalleryImageAdapter extends ArrayAdapter<Image> {
 
-  public GalleryImageAdapter(@NonNull Context context,
-      Image[] imageItemArray) {
-    super(context, 0, imageItemArray);
+  public GalleryImageAdapter(@NonNull Context context, List<Image> imageItemArray) {
+    super(context, R.layout.custom_gallery_search_spinner_item, imageItemArray);
   }
 
   @NonNull

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/view/GalleryListAdapter.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/view/GalleryListAdapter.java
@@ -11,17 +11,18 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import edu.cnm.deepdive.browseimgur.R;
-import edu.cnm.deepdive.browseimgur.model.entity.Gallery;
+import edu.cnm.deepdive.browseimgur.model.Gallery;
+import edu.cnm.deepdive.browseimgur.model.Image;
+import java.util.List;
 
 public class GalleryListAdapter extends
-    RecyclerView.Adapter<GalleryListAdapter.GalleryViewHolder> implements
-    OnItemSelectedListener {
+    RecyclerView.Adapter<GalleryListAdapter.GalleryViewHolder> {
 
   private final Context context;
-  private final Gallery[] galleries;
+  private final List<Gallery> galleries;
   private final OnItemSelectedHelper onItemSelectedHelper;
 
-  public GalleryListAdapter(Context context, Gallery[] galleries,
+  public GalleryListAdapter(Context context, List<Gallery> galleries,
       OnItemSelectedHelper onItemSelectedHelper) {
     super();
     this.context = context;
@@ -43,44 +44,52 @@ public class GalleryListAdapter extends
 
   @Override
   public int getItemCount() {
-    return galleries.length;
+    return galleries.size();
   }
 
-  @Override
-  public void onItemSelected(AdapterView<?> adapterView, View view, int pos, long l) {
-    onItemSelectedHelper.onSelected(pos, galleries[pos]);
-  }
-
-  @Override
-  public void onNothingSelected(AdapterView<?> adapterView) {
-  }
-
-  class GalleryViewHolder extends RecyclerView.ViewHolder {
+  class GalleryViewHolder extends RecyclerView.ViewHolder implements OnItemSelectedListener {
 
     private final TextView title;
     private final TextView description;
-    public final Spinner imageSpinner;
+    private final Spinner imageSpinner;
+
+    private Gallery gallery;
+    private boolean handleSelection;
 
     public GalleryViewHolder(@NonNull View itemView) {
       super(itemView);
       title = itemView.findViewById(R.id.title);
       description = itemView.findViewById(R.id.description);
       imageSpinner = itemView.findViewById(R.id.gallery_search_spinner);
-      imageSpinner.setOnItemSelectedListener(GalleryListAdapter.this);
     }
 
     private void bind(int position) {
-      title.setText(galleries[position].getTitle());
-      description.setText(galleries[position].getDescription());
-      GalleryImageAdapter galleryImageAdapter = new GalleryImageAdapter(context,
-          galleries[position].getImages());
+      gallery = galleries.get(position);
+      title.setText(gallery.getTitle());
+      description.setText(gallery.getDescription());
+      GalleryImageAdapter galleryImageAdapter = new GalleryImageAdapter(context, gallery.getImages());
       imageSpinner.setAdapter(galleryImageAdapter);
+      handleSelection = false;
+      imageSpinner.setOnItemSelectedListener(this);
+    }
+
+    @Override
+    public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+      if (handleSelection) {
+        onItemSelectedHelper.onSelected(gallery, gallery.getImages().get(position));
+      } else {
+        handleSelection = true;
+      }
+    }
+
+    @Override
+    public void onNothingSelected(AdapterView<?> parent) {
+
     }
   }
 
   public interface OnItemSelectedHelper {
-    void onSelected(int pos, Gallery gallery);
+    void onSelected(Gallery gallery, Image image);
   }
-
 
 }

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/viewmodel/ListViewModel.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/viewmodel/ListViewModel.java
@@ -15,12 +15,12 @@ import java.util.List;
 
 public class ListViewModel extends AndroidViewModel {
 
-  private MutableLiveData<List<Gallery>> galleries;
-  private MutableLiveData<Boolean> loadError = new MutableLiveData<Boolean>();
-  private MutableLiveData<Boolean> loading = new MutableLiveData<Boolean>();
-  private MutableLiveData<Throwable> throwable;
-  private CompositeDisposable pending;
-  ImgurService imgurService;
+  private final MutableLiveData<List<Gallery>> galleries;
+  private final MutableLiveData<Boolean> loadError;
+  private final MutableLiveData<Boolean> loading;
+  private final MutableLiveData<Throwable> throwable;
+  private final CompositeDisposable pending;
+  private final ImgurService imgurService;
 
   public ListViewModel(@NonNull Application application) {
     super(application);

--- a/app/src/main/java/edu/cnm/deepdive/browseimgur/viewmodel/ListViewModel.java
+++ b/app/src/main/java/edu/cnm/deepdive/browseimgur/viewmodel/ListViewModel.java
@@ -7,14 +7,15 @@ import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import edu.cnm.deepdive.browseimgur.BuildConfig;
-import edu.cnm.deepdive.browseimgur.model.entity.Gallery;
+import edu.cnm.deepdive.browseimgur.model.Gallery;
 import edu.cnm.deepdive.browseimgur.service.ImgurService;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
+import java.util.List;
 
 public class ListViewModel extends AndroidViewModel {
 
-  private MutableLiveData<Gallery.SearchResult> searchResult;
+  private MutableLiveData<List<Gallery>> galleries;
   private MutableLiveData<Boolean> loadError = new MutableLiveData<Boolean>();
   private MutableLiveData<Boolean> loading = new MutableLiveData<Boolean>();
   private MutableLiveData<Throwable> throwable;
@@ -24,16 +25,16 @@ public class ListViewModel extends AndroidViewModel {
   public ListViewModel(@NonNull Application application) {
     super(application);
     imgurService = ImgurService.getInstance();
-    searchResult = new MutableLiveData<Gallery.SearchResult>();
-    throwable = new MutableLiveData<Throwable>();
-    loadError = new MutableLiveData<Boolean>();
-    loading = new MutableLiveData<Boolean>();
+    galleries = new MutableLiveData<>();
+    throwable = new MutableLiveData<>();
+    loadError = new MutableLiveData<>();
+    loading = new MutableLiveData<>();
     pending = new CompositeDisposable();
     loadData();
   }
 
-  public LiveData<Gallery.SearchResult> getSearchResult() {
-    return searchResult;
+  public LiveData<List<Gallery>> getGalleries() {
+    return galleries;
   }
 
   public LiveData<Boolean> getLoading() {
@@ -55,9 +56,15 @@ public class ListViewModel extends AndroidViewModel {
         imgurService.getSearchResult(BuildConfig.CLIENT_ID,
             "fish AND sharks")
             .subscribeOn(Schedulers.io())
+            .map((result) -> {
+              List<Gallery> galleries = result.getData();
+              galleries.removeIf((gallery) ->
+                  gallery.getImages() == null || gallery.getImages().isEmpty());
+              return galleries;
+            })
             .subscribe(
-                searchResult -> this.searchResult.postValue(searchResult),
-                throwable -> this.throwable.postValue(throwable.getCause())
+                galleries::postValue,
+                throwable::postValue
             )
     );
   }


### PR DESCRIPTION
A few things:

* When we first scoped out the `OnItemSelectedListener` for your spinner, we forgot that we need to pass along not only the current gallery, but also the selected image. That's addressed here in a number of ways:

    * Modify the `OnItemSelectedHelper`, so that the `onSelected` method takes a `Gallery` and an `Image` as parameters.

    * Move the implementation of `OnItemSelectedListener` into `GalleryViewHolder`; the latter knows about the spinner, while the former doesn't.

    * Modify the `GallerySearchFragment.onSelected` method to take the relevant parameters.

* Getting arrays back from Retrofit is much less flexible than getting lists. Among other actual and potential issues:

    * You can't filter out items from an array, but you can from a list (e.g. using `removeIf`). Right now, you have several galleries returned that actually have no images at all, so there are `NullPointerException` instances being thrown when you try to create your `GalleryListAdapter`; however, if you filter the list of galleries returned by Imgur, you can exclude those without an `images` property.

    * You may to want to insert an item at position 0 in your images collections, so that you can detect changes from this position in the spinner (see below); that's much more difficult with arrays.

* The `onItemSelected` event gets fired as soon as you set the listener; this is the documented behavior, and it's a pain in the ass. You can, however, work around it with a boolean flag (`GalleryViewHolder.handleSelection`) that's initially set to `false`, and toggled to true after the first `onItemSelected`. This eliminates the immediate pop-ups.

* I recommend not returning a `Gallery.SearchResult` to the consumer. Instead, you can use `map` in the RxJava chain (in `loadData`) to map the `Gallery.SearchResult` to `List<Gallery>` (and then filter based on `images` being non-null and non-empty).

* As mentioned above, you might want to insert add an `Image` with a generic gallery icon in position 0 of the `List<Image>` passed to the `GalleryImageAdapter` constructor. This would avoid the problem of `onItemSelected` not being invoked when the user clicks on the spinner, and selects item 0 (which starts out selected by default).